### PR TITLE
Feat : CalculatorViewModel 상태(state) 관리

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -85,7 +85,7 @@ dependencies {
     // koin DI
     implementation "org.koin:koin-android:$koin_version"
     //implementation "org.koin:koin-android-scope:$koin_version"
-    implementation "org.koin:koin-android-viewmodel:$koin_version"
+    implementation "org.koin:koin-androidx-viewmodel:$koin_version"
     //implementation "org.koin:koin-android-ext:$koin_version"
 
     // OkHttp3

--- a/app/src/main/java/sang/gondroid/calingredientfood/di/AppModule.kt
+++ b/app/src/main/java/sang/gondroid/calingredientfood/di/AppModule.kt
@@ -1,7 +1,8 @@
 package sang.gondroid.calingredientfood.di
 
+import androidx.lifecycle.SavedStateHandle
 import kotlinx.coroutines.Dispatchers
-import org.koin.android.viewmodel.dsl.viewModel
+import org.koin.androidx.viewmodel.dsl.viewModel
 import org.koin.core.qualifier.named
 import org.koin.dsl.module
 import sang.gondroid.calingredientfood.data.repository.FoodNtrIrdntRepositoryImpl
@@ -15,9 +16,9 @@ import sang.gondroid.calingredientfood.presentation.widget.MainViewPagerAdapter
 val appModule = module {
 
     /**
-     * viewModel
+     * viewModel : SavedStateHandle 인스턴스를 받는 ViewModel 설정
      */
-    viewModel { CalculatorViewModel(get()) }
+    viewModel { (state : SavedStateHandle) -> CalculatorViewModel(state, get()) }
     viewModel { DietViewModel() }
 
     /**

--- a/app/src/main/java/sang/gondroid/calingredientfood/presentation/calculator/CalculatorFragment.kt
+++ b/app/src/main/java/sang/gondroid/calingredientfood/presentation/calculator/CalculatorFragment.kt
@@ -1,11 +1,11 @@
 package sang.gondroid.calingredientfood.presentation.calculator
 
-import org.koin.android.viewmodel.ext.android.viewModel
+import org.koin.androidx.viewmodel.ext.android.stateViewModel
 import sang.gondroid.calingredientfood.databinding.FragmentCalculatorBinding
 import sang.gondroid.calingredientfood.presentation.base.BaseFragment
 
 class CalculatorFragment : BaseFragment<FragmentCalculatorBinding, CalculatorViewModel>() {
-    override val viewModel: CalculatorViewModel by viewModel()
+    override val viewModel: CalculatorViewModel by stateViewModel()
 
     override fun getDataBinding(): FragmentCalculatorBinding = FragmentCalculatorBinding.inflate(layoutInflater)
 

--- a/app/src/main/java/sang/gondroid/calingredientfood/presentation/calculator/CalculatorViewModel.kt
+++ b/app/src/main/java/sang/gondroid/calingredientfood/presentation/calculator/CalculatorViewModel.kt
@@ -5,26 +5,55 @@ import sang.gondroid.calingredientfood.presentation.base.BaseViewModel
 import android.widget.AdapterView
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.launch
 import sang.gondroid.calingredientfood.data.util.TaskResult
 import sang.gondroid.calingredientfood.domain.model.FoodNtrIrdntModel
 import sang.gondroid.calingredientfood.domain.model.Model
 import sang.gondroid.calingredientfood.domain.use_case.GetFoodNtrIrdntUseCase
+import sang.gondroid.calingredientfood.presentation.util.Constants
 import sang.gondroid.calingredientfood.presentation.util.SearchMode
 import sang.gondroid.calingredientfood.presentation.util.DebugLog
 
 class CalculatorViewModel(
+    private val state: SavedStateHandle,
     private val getFoodNtrIrdntUseCase: GetFoodNtrIrdntUseCase
 ) : BaseViewModel() {
 
     /**
-     * Gon [22.01.20] : LiveData를 이용해 값이 변경되면 BindingAdapter.submitList() 메서드가 호출됨
+     * Gon [22.01.25] : Spinner 선택된 아이템(SearchMode)을 이용해 set / get
+     *                  key값을 이용해 개체를 저장/검색 가능한 Map인 SavedStateHandle을 이용해 상태(state) 관리
+     */
+    var currentSearchMode = state.get<SearchMode>(Constants.SEARCH_MODE_KEY) ?: SearchMode.FOOD
+        private set(value) {
+            state.set(Constants.SEARCH_MODE_KEY, value)
+            field = value
+        }
+
+    /**
+     * Gon [22.01.25] : LiveData를 이용해 값이 변경되면 BindingAdapter.submitList() 메서드가 호출됨
+     *                  fragment_calculator.xml calculator_search_editText Hint 변경에 사용
+     */
+    val currentSearchModeLiveData: LiveData<SearchMode> = state.getLiveData(Constants.SEARCH_MODE_KEY, SearchMode.FOOD)
+
+    /**
+     * Gon [22.01.25] : 검색모드(SearchMode)를 담당하는 Spinner에서 Item 선택 시 호출
+     *                  parent.getSelectedItem() : 선택한 Item
+     */
+    fun onSelectItem(parent: AdapterView<*>, view: View?, pos: Int, id: Long) {
+        currentSearchMode = parent.selectedItem as SearchMode
+    }
+
+    /**
+     * Gon [22.01.25] : LiveData를 이용해 값이 변경되면 BindingAdapter.submitList() 메서드가 호출됨
      *                  Boilerplate code를 줄이기 위해 Model 타입으로 정의, BindingAdapter.checkType() 메서드가 Type을 검증
      */
-    private var _foodNtrIrdntModelListLiveData = MutableLiveData<List<Model>>()
-    val foodNtrIrdntModelListLiveData: LiveData<List<Model>>
-        get() = _foodNtrIrdntModelListLiveData
+    val foodNtrIrdntModelListLiveData: LiveData<List<Model>> = state.getLiveData(Constants.FOOD_NTR_IRDNT_LIST_KEY)
+
+    private fun setFoodNtrIrdntListSavedStateHandle(list: List<Model>) {
+        state.set(Constants.FOOD_NTR_IRDNT_LIST_KEY, list)
+    }
 
     /**
      * Gon [22.01.11] : onEditorEnterAction() bindingAdapter 메서드의 매개변수로 전달되는
@@ -40,12 +69,13 @@ class CalculatorViewModel(
      */
     @Suppress("UNCHECKED_CAST")
     private fun search(value: String) {
-        when(selectSearchMode()) {
+        when(currentSearchMode) {
             SearchMode.FOOD -> {
                 viewModelScope.launch {
                     when(val result = getFoodNtrIrdntUseCase.invoke(value)) {
-                        is TaskResult.Success<*> ->
-                            _foodNtrIrdntModelListLiveData.value = result.data as List<FoodNtrIrdntModel>
+                        is TaskResult.Success<*> -> {
+                            setFoodNtrIrdntListSavedStateHandle(result.data as List<FoodNtrIrdntModel>)
+                        }
 
                         is TaskResult.Fail ->
                             DebugLog.d("실패")
@@ -59,20 +89,6 @@ class CalculatorViewModel(
 
             }
         }
-    }
-
-    /**
-     * Gon [22.01.11] : 반환값을 가지는 인자를 갖지않는 고차함수
-     *                  반환값 : Spinner에 선택된 Item과 대응되는 SearchMode
-     */
-    private lateinit var selectSearchMode : () -> SearchMode
-
-    /**
-     * Gon [22.01.11] : 검색모드(SearchMode)를 담당하는 Spinner에서 Item 선택 시 호출
-     *                  parent.getSelectedItem() : 선택한 Item
-     */
-    fun onSelectItem(parent: AdapterView<*>, view: View?, pos: Int, id: Long) {
-        selectSearchMode = { parent.selectedItem as SearchMode }
     }
 
     /**

--- a/app/src/main/java/sang/gondroid/calingredientfood/presentation/diet/DietFragment.kt
+++ b/app/src/main/java/sang/gondroid/calingredientfood/presentation/diet/DietFragment.kt
@@ -1,7 +1,7 @@
 package sang.gondroid.calingredientfood.presentation.diet
 
 import org.koin.android.ext.android.inject
-import org.koin.android.viewmodel.ext.android.viewModel
+import org.koin.androidx.viewmodel.ext.android.viewModel
 import sang.gondroid.calingredientfood.databinding.FragmentDietBinding
 import sang.gondroid.calingredientfood.presentation.base.BaseFragment
 

--- a/app/src/main/java/sang/gondroid/calingredientfood/presentation/util/Constants.kt
+++ b/app/src/main/java/sang/gondroid/calingredientfood/presentation/util/Constants.kt
@@ -1,5 +1,18 @@
 package sang.gondroid.calingredientfood.presentation.util
 
 object Constants {
+    /**
+     * Gon [22.01.25] : FragmentManager에 해당 상수를 TAG로 BottomSheetDialogFragment를 추가하여 표시하기 위해 사용되는 상수 정의
+     */
     const val BOTTOM_SHEET_TAG : String = "FOOD_NTR_IRDNT_BOTTOM_SHEET"
+
+    /**
+     * Gon [22.01.25] : SaveStateHandle의 Key값으로 사용되는 상수 정의
+     */
+    const val SEARCH_MODE_KEY : String = "CURRENT_SEARCH_MODE"
+
+    /**
+     * Gon [22.01.25] : SaveStateHandle의 Key값으로 사용되는 상수 정의
+     */
+    const val FOOD_NTR_IRDNT_LIST_KEY : String = "SELLECT_FOOD_NTR_IRDNT_LIST"
 }

--- a/app/src/main/java/sang/gondroid/calingredientfood/presentation/util/SearchMode.kt
+++ b/app/src/main/java/sang/gondroid/calingredientfood/presentation/util/SearchMode.kt
@@ -9,8 +9,9 @@ import sang.gondroid.calingredientfood.R
  */
 enum class SearchMode(
     @DrawableRes val modelImage: Int,
-    @StringRes val modelName: Int
+    @StringRes val modelName: Int,
+    @StringRes val modelDescription: Int
 ) {
-    FOOD(R.drawable.ic_food_bank, R.string.food),
-    DATE(R.drawable.ic_calendar_month, R.string.date);
+    FOOD(R.drawable.ic_food_bank, R.string.food, R.string.please_word),
+    DATE(R.drawable.ic_calendar_month, R.string.date, R.string.please_date);
 }

--- a/app/src/main/res/layout/fragment_calculator.xml
+++ b/app/src/main/res/layout/fragment_calculator.xml
@@ -7,7 +7,6 @@
             name="calculatorViewModel"
             type="sang.gondroid.calingredientfood.presentation.calculator.CalculatorViewModel" />
 
-
         <variable
             name="handler"
             type="sang.gondroid.calingredientfood.presentation.calculator.CalculatorFragment" />
@@ -34,7 +33,7 @@
 
                 <Spinner
                     android:id="@+id/calculator_search_mode_spinner"
-                    setSpinner="@{0}"
+                    setSpinner="@{calculatorViewModel.currentSearchMode}"
                     android:onItemSelected="@{calculatorViewModel::onSelectItem}"
                     android:layout_width="wrap_content"
                     android:layout_height="48dp"
@@ -48,7 +47,7 @@
                     android:layout_height="48dp"
                     android:layout_marginLeft="10dp"
                     android:layout_marginRight="20dp"
-                    android:hint="@string/please_word" />
+                    android:hint="@{calculatorViewModel.currentSearchModeLiveData.modelDescription}" />
 
             </LinearLayout>
         </soup.neumorphism.NeumorphCardView>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -2,6 +2,7 @@
     <string name="app_name">CalIngredientFood</string>
 
     <string name="please_word">식품명 입력</string>
+    <string name="please_date">날짜 입력</string>
     <string name="please_enter_a_search_term">검색어를 입력해주세요.</string>
 
     <string name="add">추가</string>


### PR DESCRIPTION
1. SavedStateHandle을 이용한 CalculatorViewModel 상태 관리
2. BindingAdapter.setAdapterAndSelection()에서 Spinner에서 기본값으로 선택될 항목을 설정하되, onItemSelected()를 호출하지 않도록 수정
3. SavedStateHandle을 이용해 관리하는 CalculatorViewModel의 currentSearchLiveData를 통해 fragment_calculator.xml의 calculator_search_editText Hint 변경

Working: #9 