### PR TITLE
fix: 식품 영양 성분 중복 문제 해결

### DIFF
--- a/.idea/deploymentTargetDropDown.xml
+++ b/.idea/deploymentTargetDropDown.xml
@@ -7,11 +7,11 @@
         <deviceKey>
           <Key>
             <type value="VIRTUAL_DEVICE_PATH" />
-            <value value="C:\Users\Gon\.android\avd\Pixel_4_API_24.avd" />
+            <value value="C:\Users\Gon\.android\avd\Pixel_5_API_31_3.avd" />
           </Key>
         </deviceKey>
       </Target>
     </targetSelectedWithDropDown>
-    <timeTargetWasSelectedWithDropDown value="2022-05-11T12:44:43.041513100Z" />
+    <timeTargetWasSelectedWithDropDown value="2022-05-19T13:01:08.798985100Z" />
   </component>
 </project>

--- a/app/src/main/java/sang/gondroid/calingredientfood/presentation/meal/MealFragment.kt
+++ b/app/src/main/java/sang/gondroid/calingredientfood/presentation/meal/MealFragment.kt
@@ -22,6 +22,7 @@ import sang.gondroid.calingredientfood.R
 import sang.gondroid.calingredientfood.databinding.FragmentMealBinding
 import sang.gondroid.calingredientfood.domain.model.FoodNtrIrdntModel
 import sang.gondroid.calingredientfood.domain.model.Model
+import sang.gondroid.calingredientfood.domain.util.ViewType
 import sang.gondroid.calingredientfood.presentation.base.BaseFragment
 import sang.gondroid.calingredientfood.presentation.insert.InsertFoodNtrIrdntActivity
 import sang.gondroid.calingredientfood.presentation.util.Constants
@@ -243,18 +244,20 @@ internal class MealFragment : BaseFragment<FragmentMealBinding, MealViewModel>()
     }
 
     /**
-     * Gon [22.03.03] : MainActivity에서 FragmentListener의 sendCalculatorItem()에 의해 호출됨
+     * Gon [22.05.19] : MainActivity에서 FragmentListener의 sendCalculatorItem()에 의해 호출됨
      *                  Fragment가 초기화 되지않은 상태에서 ViewModel을 호출할 수 없기 때문에 Lifecycle 상태가
-     *                  INITIALIZED인 경우 calculatorSet에 담아둠
+     *                  INITIALIZED인 경우 calculatorSet에 담아두었다가
      *                  STARTED로 변경가 호출된 경우부턴 viewModel.addCalculatorItem() 호출
      */
-    fun receiveCalculatorItem(model: FoodNtrIrdntModel): Boolean =
-        if (lifecycle.currentState == Lifecycle.State.INITIALIZED) {
-            calculatorSet.add(model)
-                .not()
+    fun receiveCalculatorItem(model: FoodNtrIrdntModel): Boolean {
+        val newModel = model.copy(type = ViewType.CALCULATOR)
+
+        return if (lifecycle.currentState == Lifecycle.State.INITIALIZED) {
+            calculatorSet.add(newModel).not()
         } else {
-            viewModel.addCalculatorItem(model)
+            viewModel.addCalculatorItem(newModel).not()
         }
+    }
 
     override fun observeData() {}
 }

--- a/app/src/main/java/sang/gondroid/calingredientfood/presentation/meal/MealViewModel.kt
+++ b/app/src/main/java/sang/gondroid/calingredientfood/presentation/meal/MealViewModel.kt
@@ -35,19 +35,18 @@ internal class MealViewModel(
     val selectPictureUri: MutableLiveData<Uri> = MutableLiveData()
 
     /**
-     * Gon [22.02.26] : 매개변수로 넘어온 model과 동일한 FoodNtrIrdntModel을 calculatorList에 추가
+     * Gon [22.05.19] : 매개변수로 넘어온 model과 동일한 FoodNtrIrdntModel을 calculatorList에 추가
      *                  동일한 descriptionKOR을 가진 FoodNtrIrdntModel이 존재하는 경우 false를 반환
      *                  LiveData를 이용해 값이 변경되면 fragment_calculator.xml의 표현식을 통해 BindingAdapter.submitList() 메서드가 호출됨
      */
     fun addCalculatorItem(model: FoodNtrIrdntModel): Boolean {
-        val newModel = model.copy(type = ViewType.CALCULATOR)
-
         calculatorList.forEach {
-            if (it.descriptionKOR == model.descriptionKOR)
+            if (it.descriptionKOR == model.descriptionKOR) {
                 return false
+            }
         }
 
-        calculatorList.add(newModel)
+        calculatorList.add(model)
         _calculatorUIStateLiveData.postValue(UIState.Success(calculatorList.toList()))
         return true
     }


### PR DESCRIPTION
원인: SearchFragment에서 식품 영양 성분 Item 추가 시 lifecycle로 인해 MealFragment의 상태가 INITIALIZED인 경우 MealFragment에서 데이터를 관리하고 STARTED인 경우 MealViewModel에서 관리하도록 처리했는데, MealViewModel의 addCalculatorItem() 메서드의 반환값이 반대로 전달되어 발생한 문제

해결: MealFragment의 receiveCalculatorItem() 메서드에서 MealViewModel의 addCalculatorItem() 메서드의 반환값을 올바르게 반환하도록 수정

Resolve: #53